### PR TITLE
Devops on Heroku: Procfile for auto migrations each release

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec puma -C config/puma.rb
+release: bundle exec rake db:migrate


### PR DESCRIPTION
## Why

This pull request is needed because:

Automation of migrations each time a new release is out on heroku, saves time incase we forget to run rails db:migrate on heroku


## What

This pull request introduces the following:

Enables auto migrations on heroku each time a new release is out


## Other

** If your migrations have an issue, it may break the staging. Please be careful!
