### PR TITLE
Set color scheme

### DIFF
--- a/app/assets/stylesheets/components/_clipboard.scss
+++ b/app/assets/stylesheets/components/_clipboard.scss
@@ -16,9 +16,9 @@
   right: 5px;
   border-radius: 5px;
   background-color: $sunset-red;
+  color: white;
 
   &:hover {
-    color: $light-yellow;
     background-color: $sunset-red-dark;
   }
 }

--- a/app/assets/stylesheets/components/_clipboard.scss
+++ b/app/assets/stylesheets/components/_clipboard.scss
@@ -1,8 +1,8 @@
 .clipboard-text {
-    background-color: #d4d1d1;
-    border-radius: 5px;
-    font-size: 1rem;
-    font-family: 'loveloblack';
+  background-color: $light-yellow;
+  border-radius: 5px;
+  font-size: 1rem;
+  font-family: $chomp-font-black;
 }
 
 .clipboard-form-control {
@@ -15,9 +15,15 @@
   bottom: 8px;
   right: 5px;
   border-radius: 5px;
+  background-color: $sunset-red;
+
+  &:hover {
+    color: $light-yellow;
+    background-color: $sunset-red-dark;
+  }
 }
 
 .clipboard-form-control .clipboard-text {
   height: 3.5rem;
-  border: 1px solid #E7E7E7;
+  border: 1px solid $sunset-red;
 }

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -9,6 +9,6 @@
   }
   .btn {
     width: 100%;
-    margin-bottom: 20px
+    margin-bottom: 20px;
   }
 }

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -4,11 +4,8 @@
   margin-top: 50px;
   border-radius: 3px;
   h2 {
-    font-size: 25px;
-    font-weight: bold;
     margin-bottom: 30px;
     text-align: center;
-    font-family: 'loveloblack';
   }
   .btn {
     width: 100%;

--- a/app/assets/stylesheets/config/_bootstrap_variables.scss
+++ b/app/assets/stylesheets/config/_bootstrap_variables.scss
@@ -23,3 +23,6 @@ $border-radius-lg: 8px;
 $border-radius-sm: 2px;
 
 // Override other variables below!
+#bootstrap-overrides.btn-info {
+  color: $sunset-red;
+}

--- a/app/assets/stylesheets/config/_bootstrap_variables.scss
+++ b/app/assets/stylesheets/config/_bootstrap_variables.scss
@@ -11,9 +11,9 @@ $font-size-base: 1rem;
 
 // Colors
 $body-color: $gray;
-$primary:    black;
-$success:    white;
-$info:       $yellow;
+$primary:    $sunset-red;
+$success:    $light-orange;
+$info:       $light-yellow;
 $danger:     $red;
 $warning:    $orange;
 

--- a/app/assets/stylesheets/config/_bootstrap_variables.scss
+++ b/app/assets/stylesheets/config/_bootstrap_variables.scss
@@ -25,4 +25,8 @@ $border-radius-sm: 2px;
 // Override other variables below!
 #bootstrap-overrides.btn-info {
   color: $sunset-red;
+
+  &:hover {
+    color: $sunset-red-dark;
+  }
 }

--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -10,6 +10,6 @@ $gray: #0E0000;
 $light-gray: #F4F4F4;
 $pink: #EC9CD3;
 $sunset-red: #EA4B5C; // - sunset red (primary)
-$sunset-red-dark: rgb(190, 35, 50);
+$sunset-red-dark: #E5293D;
 $light-yellow: #FDF4D6; // - light yellow
 $light-orange: #F2AD7B; // - light orange (secondary)

--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -10,5 +10,6 @@ $gray: #0E0000;
 $light-gray: #F4F4F4;
 $pink: #EC9CD3;
 $sunset-red: #EA4B5C; // - sunset red (primary)
+$sunset-red-dark: rgb(190, 35, 50);
 $light-yellow: #FDF4D6; // - light yellow
 $light-orange: #F2AD7B; // - light orange (secondary)

--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -4,8 +4,11 @@
 $red: #FD1015;
 $blue: #167FFB;
 $yellow: #FFC65A;
-$orange: #E67E22;
+$orange: #EE7A62; // - orange
 $green: #1EDD88;
 $gray: #0E0000;
 $light-gray: #F4F4F4;
 $pink: #EC9CD3;
+$sunset-red: #EA4B5C; // - sunset red (primary)
+$light-yellow: #FDF4D6; // - light yellow
+$light-orange: #F2AD7B; // - light orange (secondary)

--- a/app/assets/stylesheets/config/_fonts.scss
+++ b/app/assets/stylesheets/config/_fonts.scss
@@ -1,10 +1,6 @@
 // Import Google fonts
 @import url('https://fonts.googleapis.com/css?family=Nunito:400,700|Work+Sans:400,700&display=swap');
 
-// Define fonts for body and headers
-$body-font: "Work Sans", "Helvetica", "sans-serif";
-$headers-font: "Nunito", "Helvetica", "sans-serif";
-
 // To use a font file (.woff) uncomment following lines
 // @font-face {
 //   font-family: "Font Name";
@@ -43,3 +39,11 @@ $headers-font: "Nunito", "Helvetica", "sans-serif";
     font-style: normal;
 
 }
+
+$chomp-font: "loveloline_bold";
+$chomp-font-light: "loveloline_light";
+$chomp-font-black: "loveloblack";
+
+// Define fonts for body and headers
+$body-font: "Work Sans", "Helvetica", "sans-serif";
+$headers-font: $chomp-font, "Helvetica", "sans-serif";

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -1,1 +1,17 @@
 // Specific CSS for your home-page
+#home-form {
+  [type="submit"] {
+    height: 3.5rem;
+    width: 3.5rem;
+    background-color: $sunset-red;
+    border: none;
+    color: $light-yellow;
+
+    &:hover {
+      background-color: $sunset-red-dark;
+    }
+  }
+  .form-control {
+    border-radius: 0;
+  }
+}

--- a/app/assets/stylesheets/pages/_success.scss
+++ b/app/assets/stylesheets/pages/_success.scss
@@ -1,14 +1,13 @@
 .success-header {
-    font-family: $chomp-font;
+  font-family: $chomp-font;
 }
 
 .success-body {
-    font-family: $chomp-font-black;
+  font-family: $chomp-font-black;
 }
 
 .session-link {
-    background-color: #d4d1d1;
-    border-radius: 5px;
-    font-size: 1.5rem;
-    word-wrap: break-word;
+  border-radius: 5px;
+  font-size: 1.5rem;
+  word-wrap: break-word;
 }

--- a/app/assets/stylesheets/pages/_success.scss
+++ b/app/assets/stylesheets/pages/_success.scss
@@ -1,9 +1,9 @@
 .success-header {
-    font-family: 'loveloline_bold';
+    font-family: $chomp-font;
 }
 
 .success-body {
-    font-family: 'loveloblack';
+    font-family: $chomp-font-black;
 }
 
 .session-link {

--- a/app/views/chomp_sessions/success.html.erb
+++ b/app/views/chomp_sessions/success.html.erb
@@ -23,7 +23,7 @@
 
         <div class="d-flex align-items-center flex-column">
           <%= link_to "Submit my preferences", chomp_session_path(@chomp_session), class: "btn btn-primary btn-lg" %>
-          <%= link_to "Edit Chomp settings", edit_chomp_session_path(@chomp_session), class: "btn btn-outline-primary btn-lg" %>
+          <%= link_to "Edit Chomp settings", edit_chomp_session_path(@chomp_session), class: "btn btn-info btn-lg" %>
         </div>
 
       </div>

--- a/app/views/chomp_sessions/success.html.erb
+++ b/app/views/chomp_sessions/success.html.erb
@@ -5,7 +5,7 @@
 
         <h1 class="success-header">Group created</h1>
         <p class="success-body">Congratulations! Your group has been created, share this link with you friends and get started on planning your next trip!</p>
-        
+
         <div data-controller="clipboard" data-clipboard-success-content="Copied!" class="clipboard-form-control form-group mb-3">
           <input type="text" value="http://localhost:3000/chomp_sessions/<%= params["chomp_session_id"] %>" data-clipboard-target="source" class="clipboard-text w-100 pl-2"/>
 
@@ -23,12 +23,11 @@
 
         <div class="d-flex align-items-center flex-column">
           <%= link_to "Submit my preferences", chomp_session_path(@chomp_session), class: "btn btn-primary btn-lg" %>
-          <%= link_to "Edit Chomp settings", edit_chomp_session_path(@chomp_session), class: "btn btn-outline-dark btn-lg" %>
+          <%= link_to "Edit Chomp settings", edit_chomp_session_path(@chomp_session), class: "btn btn-outline-primary btn-lg" %>
         </div>
 
-        
+
       </div>
     </div>
   </div>
 </div>
-

--- a/app/views/chomp_sessions/success.html.erb
+++ b/app/views/chomp_sessions/success.html.erb
@@ -9,7 +9,7 @@
         <div data-controller="clipboard" data-clipboard-success-content="Copied!" class="clipboard-form-control form-group mb-3">
           <input type="text" value="http://localhost:3000/chomp_sessions/<%= params["chomp_session_id"] %>" data-clipboard-target="source" class="clipboard-text w-100 pl-2"/>
 
-          <button type="button" data-action="clipboard#copy" data-clipboard-target="button" class="btn-flat btn-outline-dark">
+          <button type="button" data-action="clipboard#copy" data-clipboard-target="button" class="btn-flat border-0">
             <i class="fas fa-clipboard"></i> Copy
           </button>
         </div>
@@ -25,7 +25,6 @@
           <%= link_to "Submit my preferences", chomp_session_path(@chomp_session), class: "btn btn-primary btn-lg" %>
           <%= link_to "Edit Chomp settings", edit_chomp_session_path(@chomp_session), class: "btn btn-outline-primary btn-lg" %>
         </div>
-
 
       </div>
     </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -45,9 +45,9 @@
         <% end %>
           <%= link_to "<< Go Back", :back %>
         <h3 class="mt-3">Cancel my account</h3>
-        <p>Unhappy?</p> 
+        <p>Unhappy?</p>
         <div class="mb-3">
-          <%= link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete ,class: "btn btn-danger"%>
+          <%= link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete ,class: "btn btn-danger btn-sm rounded"%>
         </div>
       </div>
     </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -3,14 +3,12 @@
     <div class="col-12 col-lg-8">
       <div class="form-login">
         <%= image_tag ("https://res.cloudinary.com/du5rqng8z/image/upload/v1632458798/letschomp/profile_hbuanz.png"), alt: "chomp-logo", class: "w-100 my-3" %>
+        <%= link_to "Create a group and share", new_chomp_session_path, class: "btn btn-primary btn-block"%>
         <%= simple_form_for :chomp_session, url: root_path, method: :get do |f| %>
-            <div class="search-form-control form-group">
-                <input class="form-control text-center" type="text" name="chomped" id="chomped" placeholder="Enter Session Code"/>
-            </div>
-                <button name="button" type="submit" class="btn btn-primary btn-block">
-                Join Existing Group
-                </button>
-                <%= link_to "Create New Group", new_chomp_session_path, class: "btn btn-success btn-block btn-outline-dark"%>
+          <div id="home-form" class="search-form-control form-group d-flex align-items-center">
+            <input class="form-control text-center rounded-left" type="text" name="chomped" id="chomped" placeholder="Enter Session Code"/>
+            <button name="button" type="submit" class="rounded-right mb-0"><i class="fas fa-arrow-right"></i></button>
+          </div>
         <% end %>
       </div>
     </div>

--- a/app/views/responses/show.html.erb
+++ b/app/views/responses/show.html.erb
@@ -11,7 +11,7 @@
         <div data-controller="clipboard" data-clipboard-success-content="Copied!" class="clipboard-form-control form-group mb-3">
           <input type="text" value="http://localhost:3000/chomp_sessions/<%= params["chomp_session_id"] %>" data-clipboard-target="source" class="clipboard-text w-100 pl-2"/>
 
-          <button type="button" data-action="clipboard#copy" data-clipboard-target="button" class="btn-flat btn-outline-dark">
+          <button type="button" data-action="clipboard#copy" data-clipboard-target="button" class="btn-flat btn-outline-info">
             <i class="fas fa-clipboard"></i> Copy
           </button>
         </div>
@@ -20,7 +20,7 @@
           <%= link_to "Edit preferences", edit_response_path(@response), class: "btn btn-primary btn-lg" %>
         </div>
         <p style="font-size:0.7rem">*Note: You will need to sign in/up before you can edit your response*</p>
-        <%= link_to "Generate Results", chomp_session_result_path, class: "btn btn-primary btn-lg" %>
+        <%= link_to "Generate Results", chomp_session_result_path, class: "btn btn-info btn-lg", id: "bootstrap-overrides" %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Color scheme & basic font setup

We can use 

`$chomp-font` for the stylized thicker lines
`$chomp-font-light` for the stylized thinner lines
`$chomp-font-black` for the thick lines with no gaps inside

<img width="622" alt="Screenshot 2021-09-25 at 8 42 15 AM" src="https://user-images.githubusercontent.com/11084577/134752060-70ed4a10-410a-4abe-a307-f37a01ed0820.png">
<img width="405" alt="Screenshot 2021-09-25 at 8 42 55 AM" src="https://user-images.githubusercontent.com/11084577/134752079-a46212e7-0eec-444b-b03e-34fcfdebb157.png">


