### PR TITLE
Update email to show chomp sess link

### DIFF
--- a/app/mailers/chomp_session_mailer.rb
+++ b/app/mailers/chomp_session_mailer.rb
@@ -9,14 +9,14 @@ class ChompSessionMailer < ApplicationMailer
   def create_chomp
     mail(
       to: @chomp_session.user.email,
-      subject: "Chomp Session: '#{@chomp_session.name}' is created!"
+      subject: "Chomp Session: '#{@chomp_session.name}' is created! (#{@chomp_session.public_uid})"
     )
   end
 
   def update_chomp
     mail(
       to: @chomp_session.user.email,
-      subject: "Chomp Session: '#{@chomp_session.name}' is updated!"
+      subject: "Chomp Session: '#{@chomp_session.name}' is updated! (#{@chomp_session.public_uid})"
     )
   end
 

--- a/app/mailers/response_mailer.rb
+++ b/app/mailers/response_mailer.rb
@@ -9,14 +9,14 @@ class ResponseMailer < ApplicationMailer
   def create_response
     mail(
       to: @response.user.email,
-      subject: "Your response for '#{@chomp_session.name}' is saved!"
+      subject: "Your response for '#{@chomp_session.name}' is saved! (#{@chomp_session.public_uid})"
     )
   end
 
   def update_response
     mail(
       to: @response.user.email,
-      subject: "Your response for '#{@chomp_session.name}' is updated!"
+      subject: "Your response for '#{@chomp_session.name}' is updated! (#{@chomp_session.public_uid})"
     )
   end
 

--- a/app/views/chomp_session_mailer/create_chomp.html.erb
+++ b/app/views/chomp_session_mailer/create_chomp.html.erb
@@ -1,5 +1,7 @@
 <h3><strong><%= @chomp_session.name %></strong> is created!</h3>
 
+<h4>Chomp code: <strong><%= @chomp_session.public_uid %></strong></h4>
+
 <p>Chomping is now in progress...</p>
 <p>You'll have to wait <strong><%= pluralize(@chomp_session.session_expiry, 'hour') %></strong> before a decision is made for you.</p>
 <p>Meanwhile, go do whatever you want! Who knows, you might even come up with a decision before us... unless you can't decide.</p>

--- a/app/views/chomp_session_mailer/create_chomp.html.erb
+++ b/app/views/chomp_session_mailer/create_chomp.html.erb
@@ -7,3 +7,5 @@
 <p><strong>Meetup details:</strong><br>
 Date: <%= @chomp_session.date %><br>
 Time: <%= @chomp_session.time.strftime("%I:%M %p") %></p>
+
+<p><em>Psst...</em> Made a mistake? <%= link_to "Click here", edit_chomp_session_url(@chomp_session) %> to edit the Chomp session details.</p>

--- a/app/views/chomp_session_mailer/create_chomp.text.erb
+++ b/app/views/chomp_session_mailer/create_chomp.text.erb
@@ -1,5 +1,7 @@
 <%= @chomp_session.name %> is created!
 
+Chomp code: <%= @chomp_session.public_uid %>
+
 Chomping is now in progress...
 You'll have to wait <%= pluralize(@chomp_session.session_expiry, 'hour') %> before a decision is made for you.
 Meanwhile, go do whatever you want! Who knows, you might even come up with a decision us...

--- a/app/views/chomp_session_mailer/create_chomp.text.erb
+++ b/app/views/chomp_session_mailer/create_chomp.text.erb
@@ -7,3 +7,5 @@ Meanwhile, go do whatever you want! Who knows, you might even come up with a dec
 Meetup details:
 Date: <%= @chomp_session.date %>
 Time: <%= @chomp_session.time.strftime("%I:%M %p") %>
+
+Psst... Made a mistake? <%= link_to "Click here", edit_chomp_session_url(@chomp_session) %> to edit the Chomp session details.

--- a/app/views/chomp_session_mailer/update_chomp.html.erb
+++ b/app/views/chomp_session_mailer/update_chomp.html.erb
@@ -1,5 +1,7 @@
 <h3><strong><%= @chomp_session.name %></strong> is updated!</h3>
 
+<h4>Chomp code: <strong><%= @chomp_session.public_uid %></strong></h4>
+
 <p>Chomping is now in progress...<em>again</em>...</p>
 <p>You'll have to wait <strong><%= pluralize(@chomp_session.session_expiry, 'hour') %></strong> before a decision is made for you.</p>
 <p>Whew! Didn't know you're so indecisive you have to change the meetup details.</p>

--- a/app/views/chomp_session_mailer/update_chomp.html.erb
+++ b/app/views/chomp_session_mailer/update_chomp.html.erb
@@ -3,7 +3,7 @@
 <p>Chomping is now in progress...<em>again</em>...</p>
 <p>You'll have to wait <strong><%= pluralize(@chomp_session.session_expiry, 'hour') %></strong> before a decision is made for you.</p>
 <p>Whew! Didn't know you're so indecisive you have to change the meetup details.</p>
-<p>Hopefully that was just to fix a typo... Right?</p>
+<p>Hopefully that was just to fix a typo... <em>Right?</em></p>
 <p>Meanwhile, continue doing whatever you were up to! Let us stress over where you should eat at instead.</p>
 
 <p><strong>Meetup details:</strong><br>

--- a/app/views/chomp_session_mailer/update_chomp.html.erb
+++ b/app/views/chomp_session_mailer/update_chomp.html.erb
@@ -9,3 +9,5 @@
 <p><strong>Meetup details:</strong><br>
 Date: <%= @chomp_session.date %><br>
 Time: <%= @chomp_session.time.strftime("%I:%M %p") %></p>
+
+<p><em>Psst...</em> Made a mistake <em>again</em>? <%= link_to "Click here", edit_chomp_session_url(@chomp_session) %> to edit the Chomp session details.</p>

--- a/app/views/chomp_session_mailer/update_chomp.text.erb
+++ b/app/views/chomp_session_mailer/update_chomp.text.erb
@@ -9,3 +9,5 @@ Meanwhile, continue doing whatever you were up to! Let us stress over where you 
 Meetup details:
 Date: <%= @chomp_session.date %>
 Time: <%= @chomp_session.time.strftime("%I:%M %p") %>
+
+Psst... Made a mistake again? <%= link_to "Click here", edit_chomp_session_url(@chomp_session) %> to edit the Chomp session details.

--- a/app/views/chomp_session_mailer/update_chomp.text.erb
+++ b/app/views/chomp_session_mailer/update_chomp.text.erb
@@ -1,5 +1,7 @@
 <%= @chomp_session.name %> is updated!
 
+Chomp code: <%= @chomp_session.public_uid %>
+
 Chomping is now in progress...again...
 You'll have to wait <%= pluralize(@chomp_session.session_expiry, 'hour') %> before a decision is made for you.
 Whew! Didn't know you're so indecisive you have to change the meetup details.

--- a/app/views/response_mailer/create_response.html.erb
+++ b/app/views/response_mailer/create_response.html.erb
@@ -1,5 +1,7 @@
 <h3>Your response for '<strong><%= @chomp_session.name %></strong>' is saved!</h3>
 
+<h4>Chomp code: <strong><%= @chomp_session.public_uid %></strong></h4>
+
 <p>Chomping is in progress...</p>
 <p>You'll have to wait <strong>less than <%= pluralize(@chomp_session.session_expiry, 'hour') %></strong> before a decision is made for you.</p>
 <p>Meanwhile, go do whatever you want! Who knows, you might even come up with a decision before us... unless you can't decide.</p>

--- a/app/views/response_mailer/create_response.html.erb
+++ b/app/views/response_mailer/create_response.html.erb
@@ -7,3 +7,5 @@
 <p><strong>Meetup details:</strong><br>
 Date: <%= @chomp_session.date %><br>
 Time: <%= @chomp_session.time.strftime("%I:%M %p") %></p>
+
+<p><em>Psst...</em> Made a mistake? <%= link_to "Click here", edit_response_url(@response) %> to edit your response.</p>

--- a/app/views/response_mailer/create_response.text.erb
+++ b/app/views/response_mailer/create_response.text.erb
@@ -1,5 +1,7 @@
 Your response for '<%= @chomp_session.name %>' is saved
 
+Chomp code: <%= @chomp_session.public_uid %>
+
 Chomping is in progress...
 You'll have to wait less than <%= pluralize(@chomp_session.session_expiry, 'hour') %> before a decision is made for you.
 Meanwhile, go do whatever you want! Who knows, you might even come up with a decision before us... unless you can't decide.

--- a/app/views/response_mailer/create_response.text.erb
+++ b/app/views/response_mailer/create_response.text.erb
@@ -7,3 +7,5 @@ Meanwhile, go do whatever you want! Who knows, you might even come up with a dec
 Meetup details:
 Date: <%= @chomp_session.date %>
 Time: <%= @chomp_session.time.strftime("%I:%M %p") %>
+
+Psst... Made a mistake? <%= link_to "Click here", edit_response_url(@response) %> to edit your response.

--- a/app/views/response_mailer/update_response.html.erb
+++ b/app/views/response_mailer/update_response.html.erb
@@ -1,5 +1,7 @@
 <h3>Your response for '<strong><%= @chomp_session.name %></strong>' is updated!</h3>
 
+<h4>Chomp code: <strong><%= @chomp_session.public_uid %></strong></h4>
+
 <p>Chomping is in progress...</p>
 <p>You'll have to wait <strong>less than <%= pluralize(@chomp_session.session_expiry, 'hour') %></strong> before a decision is made for you.</p>
 <p>Whew! Didn't know you're so indecisive you have to change the response.</p>

--- a/app/views/response_mailer/update_response.html.erb
+++ b/app/views/response_mailer/update_response.html.erb
@@ -3,7 +3,7 @@
 <p>Chomping is in progress...</p>
 <p>You'll have to wait <strong>less than <%= pluralize(@chomp_session.session_expiry, 'hour') %></strong> before a decision is made for you.</p>
 <p>Whew! Didn't know you're so indecisive you have to change the response.</p>
-<p>Hopefully that was just to fix a typo... Right?</p>
+<p>Hopefully that was just to fix a typo... <em>Right?</em></p>
 <p>Meanwhile, continue doing whatever you were up to! Let us stress over where you should eat at instead.</p>
 
 <p><strong>Meetup details:</strong><br>

--- a/app/views/response_mailer/update_response.html.erb
+++ b/app/views/response_mailer/update_response.html.erb
@@ -9,3 +9,5 @@
 <p><strong>Meetup details:</strong><br>
 Date: <%= @chomp_session.date %><br>
 Time: <%= @chomp_session.time.strftime("%I:%M %p") %></p>
+
+<p><em>Psst...</em> Made a mistake <em>again</em>? <%= link_to "Click here", edit_response_url(@response) %> to edit your response.</p>

--- a/app/views/response_mailer/update_response.text.erb
+++ b/app/views/response_mailer/update_response.text.erb
@@ -9,3 +9,5 @@ Meanwhile, continue doing whatever you were up to! Let us stress over where you 
 Meetup details:
 Date: <%= @chomp_session.date %>
 Time: <%= @chomp_session.time.strftime("%I:%M %p") %>
+
+Psst... Made a mistake again? <%= link_to "Click here", edit_response_url(@response) %> to edit your response.

--- a/app/views/response_mailer/update_response.text.erb
+++ b/app/views/response_mailer/update_response.text.erb
@@ -1,5 +1,7 @@
 Your response for '<%= @chomp_session.name %>' is updated!
 
+Chomp code: <%= @chomp_session.public_uid %>
+
 Chomping is in progress...
 You'll have to wait less than <%= pluralize(@chomp_session.session_expiry, 'hour') %> before a decision is made for you.
 Whew! Didn't know you're so indecisive you have to change the response.


### PR DESCRIPTION
The email now shows the link to edit the chomp session or response
<img width="651" alt="Screenshot 2021-09-25 at 2 08 55 PM" src="https://user-images.githubusercontent.com/11084577/134760703-3372e083-4e2d-4d6b-8d66-321712e9b115.png">

<img width="660" alt="Screenshot 2021-09-25 at 2 09 23 PM" src="https://user-images.githubusercontent.com/11084577/134760714-1056da3b-b33e-4b98-8fd5-0201a627ba93.png">

