### PR TITLE
Feature/send restaurant result email

### DIFF
--- a/app/controllers/chomp_sessions_controller.rb
+++ b/app/controllers/chomp_sessions_controller.rb
@@ -48,12 +48,14 @@ class ChompSessionsController < ApplicationController
     else
       @restaurant = @chomp_session.restaurant
     end
+    # ============== Mailing logic
     @responses_arr = Response.where(chomp_session: @chomp_session.id)
     @responses_arr.each do |response|
       next if response.user.nil?
 
       RestaurantResultMailer.with(restaurant: @restaurant, chomp_session: @chomp_session, response: response).result_release.deliver_later
     end
+    # ============== End of mailing logic
     redirect_to restaurant_path(@restaurant)
   end
 

--- a/app/controllers/chomp_sessions_controller.rb
+++ b/app/controllers/chomp_sessions_controller.rb
@@ -48,7 +48,12 @@ class ChompSessionsController < ApplicationController
     else
       @restaurant = @chomp_session.restaurant
     end
-    RestaurantResultMailer.with(restaurant: @restaurant, chomp_session: @chomp_session).result_release.deliver_later
+    @responses_arr = Response.where(chomp_session: @chomp_session.id)
+    @responses_arr.each do |response|
+      next if response.user.nil?
+
+      RestaurantResultMailer.with(restaurant: @restaurant, chomp_session: @chomp_session, response: response).result_release.deliver_later
+    end
     redirect_to restaurant_path(@restaurant)
   end
 

--- a/app/controllers/chomp_sessions_controller.rb
+++ b/app/controllers/chomp_sessions_controller.rb
@@ -1,6 +1,7 @@
 class ChompSessionsController < ApplicationController
   skip_before_action :authenticate_user!, only: :show
   before_action :set_chomp_session, only: %i[edit update show]
+  before_action :set_chomp_session_specific, only: %i[success result]
 
   def new
     @chomp_session = ChompSession.new
@@ -30,9 +31,7 @@ class ChompSessionsController < ApplicationController
     end
   end
 
-  def success
-    @chomp_session = ChompSession.find_puid(params[:chomp_session_id])
-  end
+  def success; end
 
   def show
     @response = Response.new
@@ -40,7 +39,6 @@ class ChompSessionsController < ApplicationController
   end
 
   def result
-    @chomp_session = ChompSession.find_puid(params[:chomp_session_id])
     if @chomp_session.status == "pending"
       # algorithm to get recommendation
       @restaurant = Restaurant.all.sample
@@ -50,6 +48,7 @@ class ChompSessionsController < ApplicationController
     else
       @restaurant = @chomp_session.restaurant
     end
+    RestaurantResultMailer.with(restaurant: @restaurant, chomp_session: @chomp_session).result_release.deliver_later
     redirect_to restaurant_path(@restaurant)
   end
 
@@ -61,5 +60,9 @@ class ChompSessionsController < ApplicationController
 
   def set_chomp_session
     @chomp_session = ChompSession.find_puid(params[:id])
+  end
+
+  def set_chomp_session_specific
+    @chomp_session = ChompSession.find_puid(params[:chomp_session_id])
   end
 end

--- a/app/mailers/restaurant_result_mailer.rb
+++ b/app/mailers/restaurant_result_mailer.rb
@@ -5,14 +5,14 @@ class RestaurantResultMailer < ApplicationMailer
   #   en.restaurant_result_mailer.result_release.subject
   #
   def result_release
-    restaurant_name = params[:restaurant].name
-    chomp_session = params[:chomp_session]
-    responses = Response.where(chomp_session: chomp_session.id)
-    responses.each do |response|
+    @restaurant = params[:restaurant]
+    @chomp_session = params[:chomp_session]
+    @responses = Response.where(chomp_session: @chomp_session.id)
+    @responses.each do |response|
       unless response.user.nil?
         mail(
           to: response.user.email,
-          subject: "#{chomp_session.name}'s decision is out! Enjoy your meetup at #{restaurant_name}."
+          subject: "#{@chomp_session.name}'s decision is out! Enjoy your meetup at #{@restaurant.name}."
         )
       end
     end

--- a/app/mailers/restaurant_result_mailer.rb
+++ b/app/mailers/restaurant_result_mailer.rb
@@ -6,15 +6,20 @@ class RestaurantResultMailer < ApplicationMailer
   #
   def result_release
     @restaurant = params[:restaurant]
-    @chomp_session = params[:chomp_session]
-    @responses = Response.where(chomp_session: @chomp_session.id)
-    @responses.each do |response|
-      unless response.user.nil?
-        mail(
-          to: response.user.email,
-          subject: "#{@chomp_session.name}'s decision is out! Enjoy your meetup at #{@restaurant.name}."
-        )
-      end
-    end
+    chomp_session = params[:chomp_session]
+    response = params[:response]
+    mail(
+      to: response.user.email,
+      subject: "#{chomp_session.name}'s decision is out! Enjoy your meetup at #{@restaurant.name}."
+    )
+
+    # @responses.each do |response|
+    #   next if response.user.nil?
+
+    #   mail(
+    #     to: response.user.email,
+    #     subject: "#{@chomp_session.name}'s decision is out! Enjoy your meetup at #{@restaurant.name}."
+    #   )
+    # end
   end
 end

--- a/app/mailers/restaurant_result_mailer.rb
+++ b/app/mailers/restaurant_result_mailer.rb
@@ -1,0 +1,13 @@
+class RestaurantResultMailer < ApplicationMailer
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.restaurant_result_mailer.result_release.subject
+  #
+  def result_release
+    @greeting = "Hi"
+
+    mail to: "to@example.org"
+  end
+end

--- a/app/mailers/restaurant_result_mailer.rb
+++ b/app/mailers/restaurant_result_mailer.rb
@@ -12,14 +12,5 @@ class RestaurantResultMailer < ApplicationMailer
       to: response.user.email,
       subject: "#{chomp_session.name}'s decision is out! Enjoy your meetup at #{@restaurant.name}."
     )
-
-    # @responses.each do |response|
-    #   next if response.user.nil?
-
-    #   mail(
-    #     to: response.user.email,
-    #     subject: "#{@chomp_session.name}'s decision is out! Enjoy your meetup at #{@restaurant.name}."
-    #   )
-    # end
   end
 end

--- a/app/mailers/restaurant_result_mailer.rb
+++ b/app/mailers/restaurant_result_mailer.rb
@@ -1,13 +1,20 @@
 class RestaurantResultMailer < ApplicationMailer
-
   # Subject can be set in your I18n file at config/locales/en.yml
   # with the following lookup:
   #
   #   en.restaurant_result_mailer.result_release.subject
   #
   def result_release
-    @greeting = "Hi"
-
-    mail to: "to@example.org"
+    restaurant_name = params[:restaurant].name
+    chomp_session = params[:chomp_session]
+    responses = Response.where(chomp_session: chomp_session.id)
+    responses.each do |response|
+      unless response.user.nil?
+        mail(
+          to: response.user.email,
+          subject: "#{chomp_session.name}'s decision is out! Enjoy your meetup at #{restaurant_name}."
+        )
+      end
+    end
   end
 end

--- a/app/views/restaurant_result_mailer/result_release.html.erb
+++ b/app/views/restaurant_result_mailer/result_release.html.erb
@@ -1,0 +1,5 @@
+<h1>RestaurantResult#result_release</h1>
+
+<p>
+  <%= @greeting %>, find me in app/views/restaurant_result_mailer/result_release.html.erb
+</p>

--- a/app/views/restaurant_result_mailer/result_release.html.erb
+++ b/app/views/restaurant_result_mailer/result_release.html.erb
@@ -1,14 +1,14 @@
-<h3><%= @restaurant.name %></h3>
+<h3><strong><%= @restaurant.name %></strong></h3>
 <h4><%= @restaurant.address.strip %></h4>
 
 <p>Above is the name and address of the restaurant we have selected for your meetup.</p>
 <p>
   Here's some details of the restaurant that may be useful to you:<br>
   <% unless @restaurant.cuisine == "" %>
-    Cuisine type: <%= @restaurant.cuisine %><br>
+    <strong>Cuisine type:</strong> <%= @restaurant.cuisine %><br>
   <% end %>
-  Operating hours: <%= @restaurant.opening_time.strftime("%I:%M %p") %> ~ <%= @restaurant.closing_time.strftime("%I:%M %p") %><br>
-  Google review score: <%= @restaurant.google_rating %>
+  <strong>Operating hours:</strong> <%= @restaurant.opening_time.strftime("%I:%M %p") %> ~ <%= @restaurant.closing_time.strftime("%I:%M %p") %><br>
+  <strong>Google review score:</strong> <%= @restaurant.google_rating %>
 </p>
 
 <p>Thank <em>you</em> for using Chomp!</p>

--- a/app/views/restaurant_result_mailer/result_release.html.erb
+++ b/app/views/restaurant_result_mailer/result_release.html.erb
@@ -1,5 +1,14 @@
-<h1>RestaurantResult#result_release</h1>
+<h3><%= @restaurant.name %></h3>
+<h4><%= @restaurant.address.strip %></h4>
 
+<p>Above is the name and address of the restaurant we have selected for your meetup.</p>
 <p>
-  <%= @greeting %>, find me in app/views/restaurant_result_mailer/result_release.html.erb
+  Here's some details of the restaurant that may be useful to you:<br>
+  <% unless @restaurant.cuisine == "" %>
+    Cuisine type: <%= @restaurant.cuisine %><br>
+  <% end %>
+  Operating hours: <%= @restaurant.opening_time.strftime("%I:%M %p") %> ~ <%= @restaurant.closing_time.strftime("%I:%M %p") %><br>
+  Google review score: <%= @restaurant.google_rating %>
 </p>
+
+<p>Thank <em>you</em> for using Chomp!</p>

--- a/app/views/restaurant_result_mailer/result_release.html.erb
+++ b/app/views/restaurant_result_mailer/result_release.html.erb
@@ -1,5 +1,5 @@
-<h3><strong><%= @restaurant.name %></strong></h3>
-<h4><%= @restaurant.address.strip %></h4>
+<h3><strong><%= @restaurant.name %></strong><br>
+<%= @restaurant.address.strip %></h3>
 
 <p>Above is the name and address of the restaurant we have selected for your meetup.</p>
 <p>

--- a/app/views/restaurant_result_mailer/result_release.text.erb
+++ b/app/views/restaurant_result_mailer/result_release.text.erb
@@ -1,3 +1,14 @@
-RestaurantResult#result_release
+<%= @restaurant.name %>
+<%= @restaurant.address.strip %>
 
-<%= @greeting %>, find me in app/views/restaurant_result_mailer/result_release.text.erb
+Above is the name and address of the restaurant we have selected for your meetup.
+
+  Here's some details of the restaurant that may be useful to you:
+  <% unless @restaurant.cuisine == "" %>
+    Cuisine type: <%= @restaurant.cuisine %>
+  <% end %>
+  Operating hours: <%= @restaurant.opening_time.strftime("%I:%M %p") %> ~ <%= @restaurant.closing_time.strftime("%I:%M %p") %>
+  Google review score: <%= @restaurant.google_rating %>
+
+
+Thank <em>you</em> for using Chomp!

--- a/app/views/restaurant_result_mailer/result_release.text.erb
+++ b/app/views/restaurant_result_mailer/result_release.text.erb
@@ -1,0 +1,3 @@
+RestaurantResult#result_release
+
+<%= @greeting %>, find me in app/views/restaurant_result_mailer/result_release.text.erb

--- a/test/mailers/previews/restaurant_result_mailer_preview.rb
+++ b/test/mailers/previews/restaurant_result_mailer_preview.rb
@@ -1,0 +1,9 @@
+# Preview all emails at http://localhost:3000/rails/mailers/restaurant_result_mailer
+class RestaurantResultMailerPreview < ActionMailer::Preview
+
+  # Preview this email at http://localhost:3000/rails/mailers/restaurant_result_mailer/result_release
+  def result_release
+    RestaurantResultMailer.result_release
+  end
+
+end

--- a/test/mailers/restaurant_result_mailer_test.rb
+++ b/test/mailers/restaurant_result_mailer_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class RestaurantResultMailerTest < ActionMailer::TestCase
+  test "result_release" do
+    mail = RestaurantResultMailer.result_release
+    assert_equal "Result release", mail.subject
+    assert_equal ["to@example.org"], mail.to
+    assert_equal ["from@example.com"], mail.from
+    assert_match "Hi", mail.body.encoded
+  end
+
+end


### PR DESCRIPTION
Email for results:

Sends emails to all users with account about the restaurant results when the Admin of the chomp session presses "generate results".
<img width="663" alt="Screenshot 2021-09-26 at 5 01 54 PM" src="https://user-images.githubusercontent.com/11084577/134801103-01a9c8a5-186c-43ab-bc32-2ade4d7f3864.png">

### How to test

1. Use admin account to create a new group
2. Logout
3. As a guest, join the invite
4. As a guest, input pref
5. Sign up a new account with a valid email
6. Join the session with new account
7. As a new user, input pref
8. Logout
9. Login as admin again
10. Input pref as admin
11. Generate result
12. Check your inbox, you should get ONE email from your own user account
13. I will get 1 email from admin account