### PR TITLE
See number of responses for the ChompSession

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,10 +65,6 @@ GEM
     bindex (0.8.1)
     bootsnap (1.9.1)
       msgpack (~> 1.0)
-    bootstrap (5.1.0)
-      autoprefixer-rails (>= 9.1.0)
-      popper_js (>= 2.9.3, < 3)
-      sassc-rails (>= 2.0.0)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.35.3)
@@ -145,7 +141,6 @@ GEM
     pexels (0.4.0)
       requests (~> 1.0.2)
     pg (1.2.3)
-    popper_js (2.9.3)
     postmark (1.22.0)
       json
     postmark-rails (0.21.0)
@@ -290,7 +285,6 @@ PLATFORMS
 DEPENDENCIES
   autoprefixer-rails (= 10.2.5)
   bootsnap (>= 1.4.2)
-  bootstrap
   byebug
   capybara (>= 2.15)
   cloudinary (~> 1.16.0)
@@ -303,7 +297,6 @@ DEPENDENCIES
   listen (~> 3.2)
   pexels
   pg (>= 0.18, < 2.0)
-  popper_js
   postmark-rails
   pry-byebug
   pry-rails

--- a/app/models/chomp_session.rb
+++ b/app/models/chomp_session.rb
@@ -1,7 +1,7 @@
 class ChompSession < ApplicationRecord
   UID_RANGE = 111_111..999_999
   generate_public_uid generator: PublicUid::Generators::NumberRandom.new(UID_RANGE)
-  
+
   def self.find_puid(param)
     find_by! public_uid: param.split('-').first
   end
@@ -12,6 +12,7 @@ class ChompSession < ApplicationRecord
 
   belongs_to :user
   belongs_to :restaurant, optional: true
+  has_many :responses
   validates :name, :date, :time, presence: true
   attribute :status, :string, default: "pending"
   attribute :session_expiry, :integer, default: 24

--- a/app/views/responses/show.html.erb
+++ b/app/views/responses/show.html.erb
@@ -25,6 +25,7 @@
             Generate Results
           </button>
         <% end %>
+        <p style="text-align: center"> Number of Responses: <%= @chomp_session.responses.count %></p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Why

This pull request is needed because:

Everyone, especially the inviter should be able to see the number of responses so far.

[Link to Card](https://trello.com/c/7nKy20o7)

## What

This pull request introduces the following:

 * Everyone who have submitted a response can now see how many responses have been submitted


### Screenshot

![image](https://user-images.githubusercontent.com/72695565/134838411-37fc4b91-4599-460e-9976-eb3244b17f1c.png)
