### PR TITLE
Feat review count update realtime

### DIFF
--- a/app/javascript/controllers/insert_in_list_controller.js
+++ b/app/javascript/controllers/insert_in_list_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "stimulus";
 import { csrfToken } from "@rails/ujs";
 
 export default class extends Controller {
-  static targets = ['items', 'form'];
+  static targets = ['items', 'form', 'zeroReviewsNotice'];
   static values = { position: String }
 
   send(event) {
@@ -17,6 +17,16 @@ export default class extends Controller {
       .then((data) => {
         if (data.inserted_item) {
           this.itemsTarget.insertAdjacentHTML(this.positionValue, data.inserted_item);
+
+          // Update review count
+          const reviewCount = document.querySelector("#review-count");
+          const count = parseInt(reviewCount.innerText, 10) + 1;
+          reviewCount.innerText = count;
+
+          // Remove 0 reviews notice msg
+          if (this.zeroReviewsNoticeTarget) {
+            this.zeroReviewsNoticeTarget.outerHTML = ""
+          }
         }
         this.formTarget.outerHTML = data.form;
       })

--- a/app/javascript/controllers/insert_in_list_controller.js
+++ b/app/javascript/controllers/insert_in_list_controller.js
@@ -24,7 +24,8 @@ export default class extends Controller {
           reviewCount.innerText = count;
 
           // Remove 0 reviews notice msg
-          if (this.zeroReviewsNoticeTarget) {
+          const zeroReviewsNotice = document.querySelector("#zero-reviews-notice");
+          if (zeroReviewsNotice) {
             this.zeroReviewsNoticeTarget.outerHTML = ""
           }
         }

--- a/app/views/restaurants/_review.html.erb
+++ b/app/views/restaurants/_review.html.erb
@@ -1,7 +1,7 @@
 <div id="reviews">
   <div data-insert-in-list-target="items">
     <% if restaurant.reviews.blank? %>
-      <p data-insert-in-list-target="zeroReviewsNotice" class="m-4">Be the first to leave a review for <%= restaurant.name %></p>
+      <p data-insert-in-list-target="zeroReviewsNotice" class="m-4" id="zero-reviews-notice">Be the first to leave a review for <%= restaurant.name %></p>
     <% else %>
       <% restaurant.reviews.reverse.each do |review| %>
         <div data-controller="edit-review" data-edit-review-target="card">

--- a/app/views/restaurants/_review.html.erb
+++ b/app/views/restaurants/_review.html.erb
@@ -1,8 +1,7 @@
-
 <div id="reviews">
   <div data-insert-in-list-target="items">
     <% if restaurant.reviews.blank? %>
-      <p class="m-4">Be the first to leave a review for <%= restaurant.name %></p>
+      <p data-insert-in-list-target="zeroReviewsNotice" class="m-4">Be the first to leave a review for <%= restaurant.name %></p>
     <% else %>
       <% restaurant.reviews.reverse.each do |review| %>
         <div data-controller="edit-review" data-edit-review-target="card">

--- a/app/views/restaurants/show.html.erb
+++ b/app/views/restaurants/show.html.erb
@@ -24,7 +24,9 @@
               <i class="far fa-star"></i>
             <% end %>
             <%= @restaurant.google_rating.round(2) %>
-            <span class="text-muted">User Reviews: <%= @restaurant.reviews.size %></span>
+            <span class="text-muted">User Reviews:
+              <span id="review-count"><%= @restaurant.reviews.size %></span>
+            </span>
           </p>
 
           <p id="restaurant-description" class="text-left"><%=h truncate(@restaurant.description, length: 150) %></p>

--- a/app/views/reviews/_edit_review_form.html.erb
+++ b/app/views/reviews/_edit_review_form.html.erb
@@ -5,7 +5,7 @@
               action: 'submit->edit-review#update'
               }
           }) do |f| %>
-    <%= f.input :rating, collection: [['1 - Blegh!', 1], ['2 - Below Average', 2], ['3 - Alright', 3], ['4 - Not Bad', 4], ['5 - Amazing!', 5]] %>
+    <%= f.input :rating, collection: [['1 - Blegh!', 1], ['2 - Below Average', 2], ['3 - Alright', 3], ['4 - Not Bad', 4], ['5 - Amazing!', 5]], selected: review.rating %>
     <%= f.input :title, as: :string %>
     <%= f.input :content, as: :text %>
     <%= f.submit :Edit, class: "btn btn-outline-primary" %>

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -3,7 +3,7 @@
                   insert_in_list_target: "form",
                   action: 'submit->insert-in-list#send'
                 }) do |f| %>
-  <%= f.input :rating, collection: [['1 - Blegh!', 1], ['2 - Below Average', 2], ['3 - Alright', 3], ['4 - Not Bad', 4], ['5 - Amazing!', 5]] %>
+  <%= f.input :rating, collection: [['1 - Blegh!', 1], ['2 - Below Average', 2], ['3 - Alright', 3], ['4 - Not Bad', 4], ['5 - Amazing!', 5]], selected: 3 %>
   <%= f.input :title, as: :string %>
   <%= f.input :content, as: :text %>
   <%= f.button :submit , class: "btn btn-primary btn-block"%>


### PR DESCRIPTION
## Why

User review on the restaurant page is not updating realtime when user submits a new review

## What

This pull request introduces the following:

 * Now it does

### Others

There's a problem though for subsequent new reviews that the site is not able to find the message to delete.
Doesn't affect the performance.

<img width="584" alt="Screenshot 2021-09-27 at 3 59 27 PM" src="https://user-images.githubusercontent.com/11084577/134867951-580af368-d746-4128-865a-e3aaa7a701b7.png">
 