### PR TITLE
Feat generate results on expiry

### DIFF
--- a/app/jobs/chompsession_cancellation_job.rb
+++ b/app/jobs/chompsession_cancellation_job.rb
@@ -1,0 +1,8 @@
+require 'sidekiq/api'
+class ChompsessionCancellationJob < ApplicationJob
+  queue_as :default
+
+  def perform(chomp_session_id)
+    Sidekiq::ScheduledSet.new.find_job(ChompSession.find(chomp_session_id).sidekiq_jid).try(:delete)
+  end
+end

--- a/app/jobs/generate_restaurant_job.rb
+++ b/app/jobs/generate_restaurant_job.rb
@@ -10,6 +10,12 @@ class GenerateRestaurantJob < ApplicationJob
       chomp_session.status = "closed"
       chomp_session.save
     end
+    responses_arr = chomp_session.responses
+    responses_arr.each do |response|
+      next if response.user.nil?
+
+      RestaurantResultMailer.with(restaurant: restaurant, chomp_session: chomp_session, response: response).result_release.deliver_later
+    end
   end
 
   private

--- a/app/jobs/generate_restaurant_job.rb
+++ b/app/jobs/generate_restaurant_job.rb
@@ -1,0 +1,69 @@
+class GenerateRestaurantJob < ApplicationJob
+  queue_as :default
+
+  def perform(chomp_session_id)
+    chomp_session = ChompSession.find(chomp_session_id)
+    if chomp_session.status == "pending"
+      restaurant = generate_restaurant(chomp_session).first
+      restaurant = Restaurant.all.sample if restaurant.nil?
+      chomp_session.restaurant = restaurant
+      chomp_session.status = "closed"
+      chomp_session.save
+    end
+  end
+
+  private
+
+  def generate_restaurant(chomp_session)
+    # algorithm to get recommendation
+    # based on chompsession ID, get all responses
+    # find the lowest budget, convert to integer 1,2,3 or 4
+    # get frequency table of cuisines. Get the highest frequency cuisinse.
+    # If no highest frequency
+    # Get middleground of all location responses and get the highest rated restaurant with the specified cuisine.
+    responses = chomp_session.responses
+    lowest_budget = responses.minimum('budget')
+    restaurant_pricing = determine_pricing(lowest_budget)
+
+    cuisine_arr = []
+    responses.each do |response|
+      response_cuisine = response.cuisine
+      cuisine_arr << response_cuisine.slice!(1, response_cuisine.length) unless response_cuisine == [""]
+    end
+    cuisine_arr.flatten!(1)
+    tallied_result = cuisine_arr.tally
+    most_frequent_cuisine_kv = tallied_result.max_by { |_, value| value }
+
+    # check tie
+    tied_results = tallied_result.select { |_, v| v == most_frequent_cuisine_kv[1] }
+    if tied_results.length == 1
+      result_cuisine = most_frequent_cuisine_kv[0]
+      # num_votes = most_frequent_cuisine_kv[1]
+    else
+      result_cuisine = tied_results.keys.sample
+    end
+
+    # location
+    geographic_center = Geocoder::Calculations.geographic_center(responses)
+
+    # restaurant within 5km of center ordered by rating and budget
+    restaurant = Restaurant.where("pricing = ?", restaurant_pricing).cuisine_type(result_cuisine).near(geographic_center, 5).reorder('google_rating desc').limit(1)
+
+    if restaurant.empty?
+      restaurant = Restaurant.where("pricing = ?", restaurant_pricing).cuisine_type(result_cuisine).reorder('google_rating desc').limit(1)
+    end
+    return restaurant
+  end
+
+  def determine_pricing(budget)
+    if budget > 50
+      4
+    elsif budget > 25
+      3
+    elsif budget > 10
+      2
+    else
+      1
+    end
+  end
+end

--- a/db/migrate/20210927072812_add_sidekiq_jid_to_chomp_sessions.rb
+++ b/db/migrate/20210927072812_add_sidekiq_jid_to_chomp_sessions.rb
@@ -1,0 +1,5 @@
+class AddSidekiqJidToChompSessions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :chomp_sessions, :sidekiq_jid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_26_103907) do
+ActiveRecord::Schema.define(version: 2021_09_27_072812) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 2021_09_26_103907) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.time "time"
+    t.string "sidekiq_jid"
     t.index ["public_uid"], name: "index_chomp_sessions_on_public_uid", unique: true
     t.index ["restaurant_id"], name: "index_chomp_sessions_on_restaurant_id"
     t.index ["user_id"], name: "index_chomp_sessions_on_user_id"

--- a/test/jobs/chompsession_cancellation_job_test.rb
+++ b/test/jobs/chompsession_cancellation_job_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ChompsessionCancellationJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/jobs/generate_restaurant_job_test.rb
+++ b/test/jobs/generate_restaurant_job_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class GenerateRestaurantJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## Why

This pull request is needed because:

* Automation of result generation when the the session expires.
* Automation of cancelling scheduled job when inviter clicks on 'Generate Results' button before expiry.

[Link to Card](https://trello.com/c/2CZHkFpb)

## What

This pull request introduces the following:
 * Added scheduled job to generate results at session expiry.
 * Scheduled job also sends email to participants once results are generated.
 * Added sidekiq_jid (sidekiq job id) to each chompsession
 * This is to help quickly identify where the scheduled job is in redis and delete the job when the inviter manually closes the session and generates results before session expires.
 * Extra worker to actually remove the scheduled job, so that it does not block. This is a way to sidestep the sidekiq gem limitation has deletion of scheduled job has a linear run time. Underneath, it does a linear search by job id then deletes it.


## How to Test

1. Create a ChompSession in browser
2. Submit 1 user preference for that ChompSession
3. In terminal, `rails c` and type `jid = ChompSession.last.sidekiq_jid` to get the scheduled job id in sidekiq redis.
4. To get the job from sidekiq, run `Sidekiq::ScheduledSet.new.find_job(jid)`
5. Now go back to browser and click on 'Generate Results'
6. If you try to run `Sidekiq::ScheduledSet.new.find_job(jid)` again it should return nil as the scheduled job has been deleted from sidekiq redis. 🎉



