### PR TITLE
fixed edit user session alignment issue #57

### DIFF
--- a/app/assets/stylesheets/components/_tab.scss
+++ b/app/assets/stylesheets/components/_tab.scss
@@ -6,7 +6,7 @@
 .tabs-underlined .tab-underlined {
   color: black;
   padding: 8px;
-  margin: 8px 16px;
+  margin: 8px 0px;
   opacity: .4;
   cursor: pointer;
   text-decoration: none;

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -3,14 +3,18 @@
   <div class="row justify-content-center">
     <div class="col-12 col-lg-8">
       <div class="form-login">
-        <ul class="list-inline tabs-underlined">
+        <div class="tabs-underlined justify-content-center">
+          <a href="#" class="tab-underlined active">Account Settings</a>
+          <a href="#" class="tab-underlined">My Preferences</a>
+        </div>
+        <%# <ul class="list-inline tabs-underlined">
           <li>
             <a href="#" class="tab-underlined active">Account Settings</a>
           </li>
           <li>
             <a href="#" class="tab-underlined">My Preferences</a>
           </li>
-        </ul>
+        </ul> %>
 
         <h2>Edit <%= resource_name.to_s.humanize %></h2>
 


### PR DESCRIPTION
## Why

This pull request is needed because:

Fixing issue #57 . Alignment issue on edit user page.

[Link to Card](https://trello.com/c/pnC2TPs6)

## What

This pull request introduces the following:

 * Aligned the two links

`Add Implementation details if needed`

### Screenshot

Original issue: 

![image](https://user-images.githubusercontent.com/72695565/135071856-819c81bd-fb27-4862-bbcd-8963de25d289.png)


Please vote on which one u guys prefer

_justify-content-center_

![image](https://user-images.githubusercontent.com/72695565/135071389-9e5b0f44-9e03-4837-9fa0-f17a9a7cd0a0.png)

_Without justify-content-center_

![image](https://user-images.githubusercontent.com/72695565/135071670-6ab896e3-5430-485c-9843-d22fada3be89.png)

## Others

Please note that the link.. has no functionality. Whoever that implemented it as links.. do think about how it can be used.
