### PR TITLE
fixed chomp_session ykbday violating date error

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -121,7 +121,7 @@ puts "Seeding ChompSessions completed, but will only work if you created a user 
 # chompSession for response_generation
 ykbday = ChompSession.create(
     name: "Yong kee's birthday",
-    date: Date.today,
+    date: Date.tomorrow,
     time: Time.now,
     status: "pending",
     user: User.second


### PR DESCRIPTION
## Why

This pull request is needed because:

Error with db:seed because the ykbday seed was not created in the database.

## What

This pull request introduces the following:

 * Created the ykbday seed in the system to fix the error.