### PR TITLE
fix redirection routes

### DIFF
--- a/app/controllers/chomp_sessions_controller.rb
+++ b/app/controllers/chomp_sessions_controller.rb
@@ -41,11 +41,17 @@ class ChompSessionsController < ApplicationController
     end
   end
 
-  def success; end
+  def success
+    @search_exist = Response.where(user: current_user, chomp_session: @chomp_session)
+  end
 
   def show
     @response = Response.new
     redirect_to restaurant_path(@chomp_session.restaurant) if @chomp_session.status == "closed"
+    # this line is to search if the current user already submitted his preference
+    # if yes, redirect to the "preference submitted page"
+    @search_exist = Response.where(user: current_user, chomp_session: @chomp_session)
+    redirect_to chomp_session_response_url(@chomp_session,@search_exist.first) unless @search_exist == []
   end
 
   def result

--- a/app/views/chomp_sessions/success.html.erb
+++ b/app/views/chomp_sessions/success.html.erb
@@ -8,7 +8,11 @@
         <%= render "shared/meetup_details" %>
 
         <% if @chomp_session.user == current_user %>
-          <%= link_to "Enter my food choices", chomp_session_path(@chomp_session), class: "btn btn-primary btn-block btn-lg", role: "button" %>
+          <% if @search_exist == [] %>
+            <%= link_to "Enter my food choices", chomp_session_path(@chomp_session), class: "btn btn-primary btn-block btn-lg", role: "button" %>
+          <% else %>
+            <%= link_to "Enter my food choices", edit_response_path(@search_exist.first), class: "btn btn-primary btn-block btn-lg", role: "button" %>
+          <% end %>
         <% end %>
 
         <button class="btn btn-info btn-lg text-white" id="share-button">Share the link <i class="fas fa-share-alt"></i></button>


### PR DESCRIPTION
## Why

This pull request is needed because:

This is to prevent registered from submitting their preference twice by:

1. If person who alr submitted preference goes to success page and click enter my food choices, he will be directed to edit page instead of create new.
![image](https://user-images.githubusercontent.com/84527114/135554853-9b44cac6-4265-4409-b68b-7b4232412359.png)

2. If person who alr submitted preference  tries to go to the create new response page via url or session code, he will be directed to response submitted page.



