### PR TITLE
filter out responses that sessions are alr expired

### DIFF
--- a/app/controllers/chomp_sessions_controller.rb
+++ b/app/controllers/chomp_sessions_controller.rb
@@ -7,7 +7,7 @@ class ChompSessionsController < ApplicationController
 
   def dashboard
     @chomp_sessions = ChompSession.where(user: current_user).order(status: :desc, date: :asc)
-    @responses = Response.joins(:chomp_session).where(chomp_sessions: { status: 'pending' }).where(user: current_user).order(created_at: :desc)
+    @responses = Response.joins(:chomp_session).where(chomp_sessions: { status: 'pending' }).where(user: current_user).order(created_at: :asc)
   end
 
   def new

--- a/app/controllers/chomp_sessions_controller.rb
+++ b/app/controllers/chomp_sessions_controller.rb
@@ -7,7 +7,7 @@ class ChompSessionsController < ApplicationController
 
   def dashboard
     @chomp_sessions = ChompSession.where(user: current_user).order(status: :desc, date: :asc)
-    @responses = Response.where(user: current_user).order(created_at: :desc)
+    @responses = Response.joins(:chomp_session).where(chomp_sessions: { status: 'pending' }).where(user: current_user).order(created_at: :desc)
   end
 
   def new


### PR DESCRIPTION
## Why

This pull request is needed because:

So that only responses of "pending" chomp_sessions will appear